### PR TITLE
Rule: Memory size is under default max memory

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,0 +1,1 @@
+export const AWS_HISTORICAL_MAX_MEMORY = 3008;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   NoDefaultTimeout,
   NoMaxTimeout,
   NoSharedIamRoles,
+  UnderMaxMemory,
   UseArm,
 } from './rules';
 import { ChecksResults, Options, Resource, Rule, Tag } from './types';
@@ -106,6 +107,7 @@ export const runGuardianChecks = async ({
     NoSharedIamRoles,
     UseArm,
     LimitedNumberOfLambdaVersions,
+    UnderMaxMemory,
   ];
 
   let remaining = rules.length + 1;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,6 +2,7 @@ import noDefaultMemory from './noDefaultMemory';
 import LightBundleRule from './lightBundle';
 import NoDefaultTimeout from './noDefaultTimeout';
 import NoMaxTimeout from './noMaxTimeout';
+import UnderMaxMemory from './underMaxMemory';
 import NoSharedIamRoles from './noSharedIamRoles';
 import UseArm from './useArm';
 import LimitedNumberOfLambdaVersions from './limitedNumberOfVersions';
@@ -11,6 +12,7 @@ export {
   LightBundleRule,
   NoDefaultTimeout,
   NoMaxTimeout,
+  UnderMaxMemory,
   NoSharedIamRoles,
   UseArm,
   LimitedNumberOfLambdaVersions,

--- a/src/rules/underMaxMemory/index.ts
+++ b/src/rules/underMaxMemory/index.ts
@@ -1,0 +1,35 @@
+import { FunctionConfiguration } from '@aws-sdk/client-lambda';
+import { AWS_HISTORICAL_MAX_MEMORY } from '../../constants';
+import { fetchAllLambdaConfigurations } from '../../helpers';
+import {
+  CheckResult,
+  ErrorMessages,
+  Resource,
+  Rule,
+  RuleDisplayNames,
+} from '../../types';
+
+const hasMemoryUnderMaxMemory = (lambdaConfiguration: FunctionConfiguration) =>
+  lambdaConfiguration.MemorySize === undefined ||
+  lambdaConfiguration.MemorySize < AWS_HISTORICAL_MAX_MEMORY;
+const run = async (
+  resources: Resource[],
+): Promise<{
+  results: CheckResult[];
+}> => {
+  const lambdaConfigurations = await fetchAllLambdaConfigurations(resources);
+
+  const results = lambdaConfigurations.map(lambdaConfiguration => ({
+    arn: lambdaConfiguration.FunctionArn ?? '',
+    success: hasMemoryUnderMaxMemory(lambdaConfiguration),
+    memorySize: lambdaConfiguration.MemorySize,
+  }));
+
+  return { results };
+};
+
+export default {
+  ruleName: RuleDisplayNames.UNDER_MAX_MEMORY,
+  errorMessage: ErrorMessages.UNDER_MAX_MEMORY,
+  run,
+} as Rule;

--- a/src/rules/underMaxMemory/underMaxMemory.MD
+++ b/src/rules/underMaxMemory/underMaxMemory.MD
@@ -1,0 +1,18 @@
+# No Functions Have Memory Configuration To Maximum Limit (no-max-memory)
+
+Lambda Functions memory is configurable and should be configured for the use-case.
+This can impact the speed and running cost of the Lambda Function.
+
+> **Note:** Any increase in memory size triggers an equivalent increase in CPU available to your function
+
+---
+
+## Suggested Actions:
+
+- Look into your CloudWatch Logs for the Lambda function to find `Max Memory Used` [more information](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html)
+
+```
+REPORT RequestId: 3604209a-e9a3-11e6-939a-754dd98c7be3	Duration: 12.34 ms	Billed Duration: 100 ms Memory Size: 128 MB	Max Memory Used: 18 MB
+```
+
+- Power-tune using [aws-lambda-power-tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning)

--- a/src/types/Rules.ts
+++ b/src/types/Rules.ts
@@ -1,3 +1,4 @@
+import { AWS_HISTORICAL_MAX_MEMORY } from '../constants';
 export enum Rules {
   NO_DEFAULT_MEMORY = 'NO_DEFAULT_MEMORY',
   LIGHT_BUNDLE = 'LIGHT_BUNDLE',
@@ -6,6 +7,7 @@ export enum Rules {
   NO_MAX_TIMEOUT = 'NO_MAX_TIMEOUT',
   NO_SHARED_IAM_ROLES = 'NO_SHARED_IAM_ROLES',
   USE_ARM_ARCHITECTURE = 'USE_ARM_ARCHITECTURE',
+  UNDER_MAX_MEMORY = 'UNDER_MAX_MEMORY',
 }
 
 export const RuleDisplayNames = {
@@ -17,6 +19,7 @@ export const RuleDisplayNames = {
   [Rules.NO_MAX_TIMEOUT]: 'No max timeout',
   [Rules.NO_SHARED_IAM_ROLES]: 'No shared IAM roles',
   [Rules.USE_ARM_ARCHITECTURE]: 'Using an ARM Architecture',
+  [Rules.UNDER_MAX_MEMORY]: 'Memory under maximum memory limit',
 } as const;
 
 export const ErrorMessages = {
@@ -34,4 +37,5 @@ export const ErrorMessages = {
     'The following functions have roles used by 1 or more other functions.\nSee (https://theodo-uk.github.io/sls-dev-tools/docs/no-shared-roles) for impact and how to to resolve.',
   [Rules.USE_ARM_ARCHITECTURE]:
     "The function's architecture is not set as ARM. See (https://github.com/Kumo-by-Theodo/guardian/blob/master/src/rules/useArm/useArm.md) for impact and how to to resolve.",
+  [Rules.UNDER_MAX_MEMORY]: `The function's memory is set to the historical maximum limit of ${AWS_HISTORICAL_MAX_MEMORY} MB or higher. See (https://github.com/Kumo-by-Theodo/guardian/blob/master/src/rules/underMaxMemory/underMaxMemory.md) for impact and how to to resolve.`,
 } as const;


### PR DESCRIPTION
Rule of NoMaxmemory : 
- Before : Fail if the memory of the function is set to the maximum memory limit [(3008 before, now it's up to 10240 MB since 2020)](https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-supports-10gb-memory-6-vcpu-cores-lambda-functions/) 
- Now: Fail if the memory of the function is set equal or higher to the historical 3008MB limit. 

Rule renamed : **UnderMaxMemory**