### PR TITLE
Feat/add tests

### DIFF
--- a/packages/core/src/rules/noMaxTimeout/test.ts
+++ b/packages/core/src/rules/noMaxTimeout/test.ts
@@ -1,0 +1,28 @@
+import { Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { DefaultFunction } from '../../../tests/constructs';
+import { noMaxTimeout as NoMaxTimeoutRule } from './index';
+
+interface NoMaxTimeoutProps {
+  timeout?: Duration;
+}
+
+export class NoMaxTimeout extends Construct {
+  static passTestCases: Record<string, NoMaxTimeoutProps> = {
+    'no max timeout set': {
+      timeout: undefined,
+    },
+  };
+
+  static failTestCases: Record<string, NoMaxTimeoutProps> = {
+    'max timeout set to 10 min ': { timeout: Duration.seconds(900) },
+  };
+
+  constructor(scope: Construct, id: string, { timeout }: NoMaxTimeoutProps) {
+    super(scope, id);
+    const lambda = new DefaultFunction(this, 'LambdaFunction', {
+      timeout,
+    });
+    lambda.tagRule(NoMaxTimeoutRule);
+  }
+}

--- a/packages/core/src/rules/s3OnlyAllowHTTPS/test.ts
+++ b/packages/core/src/rules/s3OnlyAllowHTTPS/test.ts
@@ -1,0 +1,29 @@
+import { Construct } from 'constructs';
+import { DefaultBucket } from '../../../tests/constructs';
+import { s3OnlyAllowHTTPS as s3OnlyAllowHTTPSRule } from './index';
+
+interface S3OnlyAllowHTTPSProps {
+  enforceSSL?: boolean;
+}
+
+export class S3OnlyAllowHTTPS extends Construct {
+  static passTestCases: Record<string, S3OnlyAllowHTTPSProps> = {
+    'ssl is enforced': {
+      enforceSSL: true,
+    },
+  };
+
+  static failTestCases: Record<string, S3OnlyAllowHTTPSProps> = {
+    'ssl is not enforced': { enforceSSL: false },
+  };
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { enforceSSL }: S3OnlyAllowHTTPSProps,
+  ) {
+    super(scope, id);
+    const bucket = new DefaultBucket(this, 'S3Bucket', { enforceSSL });
+    bucket.tagRule(s3OnlyAllowHTTPSRule);
+  }
+}

--- a/packages/core/src/rules/snsRedrivePolicy/test.ts
+++ b/packages/core/src/rules/snsRedrivePolicy/test.ts
@@ -27,7 +27,7 @@ export class SnsRedrivePolicy extends Construct {
       'SnsRedrivePolicy',
       {
         deadLetterQueue: hasDeadLetterQueue
-          ? new DefaultSqsQueue(scope, `${id}-queue`)
+          ? new DefaultSqsQueue(scope, 'snsRedrivePolicyDlq')
           : undefined,
       },
     );

--- a/packages/core/src/rules/specifyDlqOnEventBridgeRule/test.ts
+++ b/packages/core/src/rules/specifyDlqOnEventBridgeRule/test.ts
@@ -34,12 +34,15 @@ export class SpecifyDlqOnEventBridge extends Construct {
       targets: eventBridgeRuleHasTargetWithDlq
         ? [
             new LambdaFunction(
-              new DefaultFunction(scope, `${id}-target`, {
-                deadLetterQueue: new DefaultSqsQueue(scope, `${id}-queue`),
+              new DefaultFunction(scope, 'target', {
+                deadLetterQueue: new DefaultSqsQueue(
+                  scope,
+                  'dlqRuleEvenBridge',
+                ),
               }),
             ),
           ]
-        : [new LambdaFunction(new DefaultFunction(scope, `${id}-target`))],
+        : [new LambdaFunction(new DefaultFunction(scope, 'target'))],
     });
     eventBridgeRule.tagRule(SpecifyDlqOnEventBridgeRule);
   }

--- a/packages/core/src/rules/specifyDlqOnSqs/test.ts
+++ b/packages/core/src/rules/specifyDlqOnSqs/test.ts
@@ -1,0 +1,34 @@
+import { Construct } from 'constructs';
+import { DefaultSqsQueue } from '../../../tests/constructs';
+import { specifyDlqOnSqs as SpecifyDlqOnSqsRule } from './index';
+
+interface SpecifyDlqOnSQSProps {
+  shouldUseDeadLetterQueue: boolean;
+}
+
+export class SpecifyDlqOnSQS extends Construct {
+  static passTestCases: Record<string, SpecifyDlqOnSQSProps> = {
+    'SQS with DLQ': {
+      shouldUseDeadLetterQueue: true,
+    },
+  };
+
+  static failTestCases: Record<string, SpecifyDlqOnSQSProps> = {
+    'SQS without DLQ': { shouldUseDeadLetterQueue: false },
+  };
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { shouldUseDeadLetterQueue }: SpecifyDlqOnSQSProps,
+  ) {
+    super(scope, id);
+    const sqs = new DefaultSqsQueue(
+      scope,
+      'sqsQueue',
+      shouldUseDeadLetterQueue ? {} : { deadLetterQueue: undefined },
+    );
+
+    sqs.tagRule(SpecifyDlqOnSqsRule);
+  }
+}

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -5,6 +5,7 @@ export * from '../src/rules/enableBlockPublicAccess/test';
 export * from '../src/rules/noDefaultMemory/test';
 export * from '../src/rules/noMaxTimeout/test';
 export * from '../src/rules/noMonoPackage/test';
+export * from '../src/rules/s3OnlyAllowHTTPS/test';
 export * from '../src/rules/snsRedrivePolicy/test';
 export * from '../src/rules/specifyDlqOnEventBridgeRule/test';
 export * from '../src/rules/underMaxMemory/test';

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -3,6 +3,7 @@ export * from '../src/rules/cognitoSignInCaseInsensitivity/test';
 export * from '../src/rules/definedLogsRetentionDuration/test';
 export * from '../src/rules/enableBlockPublicAccess/test';
 export * from '../src/rules/noDefaultMemory/test';
+export * from '../src/rules/noMaxTimeout/test';
 export * from '../src/rules/noMonoPackage/test';
 export * from '../src/rules/snsRedrivePolicy/test';
 export * from '../src/rules/specifyDlqOnEventBridgeRule/test';

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -8,6 +8,7 @@ export * from '../src/rules/noMonoPackage/test';
 export * from '../src/rules/s3OnlyAllowHTTPS/test';
 export * from '../src/rules/snsRedrivePolicy/test';
 export * from '../src/rules/specifyDlqOnEventBridgeRule/test';
+export * from '../src/rules/specifyDlqOnSqs/test';
 export * from '../src/rules/underMaxMemory/test';
 export * from '../src/rules/useArm/test';
 export * from '../src/rules/useIntelligentTiering/test';


### PR DESCRIPTION
Adding tests for the following rules : 

- only allow https requests S3
- specify a dead letter queue on SQS
- no lambda function is set with the maximum possible timeout