### PR TITLE
Cognito e2e tests

### DIFF
--- a/apps/tests/vitest.config.ts
+++ b/apps/tests/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    testTimeout: 20000,
+    testTimeout: 50000,
   },
 });

--- a/packages/core/src/rules/cognitoEnforceLongPasswords/test.ts
+++ b/packages/core/src/rules/cognitoEnforceLongPasswords/test.ts
@@ -1,0 +1,29 @@
+import { Construct } from 'constructs';
+import { cognitoEnforceLongPasswords } from './index';
+import { DefaultUserPool } from '../../../tests/constructs';
+
+interface EnforceLongPasswordsProps {
+  minLength: number;
+}
+
+export class EnforceLongPasswords extends Construct {
+  static passTestCases: Record<string, EnforceLongPasswordsProps> = {
+    'Password min lenth 10': { minLength: 10 },
+  };
+
+  static failTestCases: Record<string, EnforceLongPasswordsProps> = {
+    'Password min lenth 8': { minLength: 8 },
+  };
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { minLength }: EnforceLongPasswordsProps,
+  ) {
+    super(scope, id);
+    const userPool = new DefaultUserPool(this, 'UserPool', {
+      passwordPolicy: { minLength },
+    });
+    userPool.tagRule(cognitoEnforceLongPasswords);
+  }
+}

--- a/packages/core/src/rules/cognitoSignInCaseInsensitivity/test.ts
+++ b/packages/core/src/rules/cognitoSignInCaseInsensitivity/test.ts
@@ -1,0 +1,29 @@
+import { Construct } from 'constructs';
+import { cognitoSignInCaseInsensitivity } from './index';
+import { DefaultUserPool } from '../../../tests/constructs';
+
+interface SignInCaseInsensitivityProps {
+  signInCaseSensitive: boolean;
+}
+
+export class SignInCaseInsensitivity extends Construct {
+  static passTestCases: Record<string, SignInCaseInsensitivityProps> = {
+    'Sign in case sensitive': { signInCaseSensitive: false },
+  };
+
+  static failTestCases: Record<string, SignInCaseInsensitivityProps> = {
+    'Sign in case insensitive': { signInCaseSensitive: true },
+  };
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { signInCaseSensitive }: SignInCaseInsensitivityProps,
+  ) {
+    super(scope, id);
+    const userPool = new DefaultUserPool(this, 'UserPool', {
+      signInCaseSensitive,
+    });
+    userPool.tagRule(cognitoSignInCaseInsensitivity);
+  }
+}

--- a/packages/core/tests/constructs/defaultUserPool.ts
+++ b/packages/core/tests/constructs/defaultUserPool.ts
@@ -1,0 +1,32 @@
+import { Tags } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { CfnUserPool, UserPool, UserPoolProps } from 'aws-cdk-lib/aws-cognito';
+import { Rule } from '../../src/types';
+import { RULE_TAG_KEY, Tagger } from './tags';
+
+export class DefaultUserPool extends UserPool implements Tagger {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: Partial<UserPoolProps> | undefined = {},
+  ) {
+    super(
+      scope,
+      id,
+      Object.assign<UserPoolProps, Partial<UserPoolProps>>(
+        {
+          passwordPolicy: { minLength: 10 },
+          signInCaseSensitive: false,
+        },
+        props,
+      ),
+    );
+  }
+
+  tagRule(rule: Rule): void {
+    Tags.of(this.node.defaultChild as CfnUserPool).add(
+      RULE_TAG_KEY,
+      rule.ruleName,
+    );
+  }
+}

--- a/packages/core/tests/constructs/index.ts
+++ b/packages/core/tests/constructs/index.ts
@@ -4,4 +4,5 @@ export * from './defaultLogGroup';
 export * from './defaultSnsSubscription';
 export * from './defaultSnsTopic';
 export * from './defaultSqsQueue';
+export * from './defaultUserPool';
 export * from './tags';

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -5,3 +5,4 @@ export * from '../src/rules/noMonoPackage/test';
 export * from '../src/rules/snsRedrivePolicy/test';
 export * from '../src/rules/useArm/test';
 export * from '../src/rules/useIntelligentTiering/test';
+export * from '../src/rules/cognitoSignInCaseInsensitivity/test';

--- a/packages/core/tests/index.ts
+++ b/packages/core/tests/index.ts
@@ -5,4 +5,5 @@ export * from '../src/rules/noMonoPackage/test';
 export * from '../src/rules/snsRedrivePolicy/test';
 export * from '../src/rules/useArm/test';
 export * from '../src/rules/useIntelligentTiering/test';
+export * from '../src/rules/cognitoEnforceLongPasswords/test';
 export * from '../src/rules/cognitoSignInCaseInsensitivity/test';


### PR DESCRIPTION
Tests for the 2 Cognito rules:

1. Cognito: use case insensitivity on the username input
2. Cognito: User Pools enforce passwords of at least 10 characters