### PR TITLE
✨ generate a table with rule name and file name of rules for doc config

### DIFF
--- a/apps/documentation/.gitignore
+++ b/apps/documentation/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 sidebars.json
 docs/rules
+docs/set-up-sls-mentor/configure-sls-mentor.md

--- a/apps/documentation/scripts/generate-docs.ts
+++ b/apps/documentation/scripts/generate-docs.ts
@@ -7,7 +7,11 @@ if (fs.existsSync(path.join(__dirname, '../docs/rules'))) {
 }
 
 fs.mkdirSync(path.join(__dirname, '../docs/rules'));
-rules.forEach(({ fileName }) => {
+
+let tableOfRuleNames = `| Rule | Name for configuration file |
+  | :- | :- |`;
+
+rules.forEach(({ fileName, ruleName }) => {
   fs.copyFileSync(
     path.join(
       __dirname,
@@ -17,4 +21,20 @@ rules.forEach(({ fileName }) => {
     ),
     path.join(__dirname, '../docs/rules', fileName + '.md'),
   );
+  tableOfRuleNames = `${tableOfRuleNames}
+  | ${ruleName} | ${fileName} |`;
 });
+
+const data = fs.readFileSync(
+  path.join(__dirname, './templates/configure-sls-mentor.md'),
+  'utf-8',
+);
+const result = data.replace(
+  /<!-- Rule table will appear here -->/g,
+  tableOfRuleNames,
+);
+fs.writeFileSync(
+  path.join(__dirname, '../docs/set-up-sls-mentor/configure-sls-mentor.md'),
+  result,
+  'utf8',
+);

--- a/apps/documentation/scripts/templates/configure-sls-mentor.md
+++ b/apps/documentation/scripts/templates/configure-sls-mentor.md
@@ -24,25 +24,7 @@ ignoredResources accepts an array of regex that you wish to ignore. You can eith
 
 The rule name should be one of the following list:
 
-<!-- Todo update rule docs to put it there -->
-
-- asyncSpecifyFailureDestination
-- cloudFrontSecurityHeaders
-- cognitoSignInCaseInsensitivity
-- definedLogsRetentionDuration
-- lightBundle
-- limitedAmountOfVersions
-- noDeprecatedRuntime
-- noMaxTimeout
-- noMonoPackage
-- noProvisionedConcurrency
-- noSharedIamRoles
-- s3OnlyAllowHTTPS
-- specifyDlqOnEventBridgeRule
-- specifyDlqOnSqs
-- underMaxMemory
-- useArm
-- useIntelligentTiering
+<!-- Rule table will appear here -->
 
 For example you can add the following:
 


### PR DESCRIPTION
<img width="1094" alt="Capture d’écran 2023-07-21 à 17 32 17" src="https://github.com/sls-mentor/sls-mentor/assets/91066744/c0bb0ee8-a1df-46ac-a659-a5c87f53b1a9">

This new table on "Configure sls-mentor" page of the documentation website is generated automatically and helps the user understand which name he needs to use in its configuration to ignore some resources for each rule.