### PR TITLE
fix(EventBridge): exclude managed rules

### DIFF
--- a/packages/core/src/aws-sdk-helpers/eventBridge/getAllRulesOfEventBus.ts
+++ b/packages/core/src/aws-sdk-helpers/eventBridge/getAllRulesOfEventBus.ts
@@ -16,9 +16,13 @@ export const getAllRulesOfEventBus = async (
       }),
     );
 
-    allEventBusRules.push(...(Rules ?? []));
+    allEventBusRules.push(...(Rules ?? []).filter(isStandardRule));
     nextToken = NextToken;
   } while (nextToken !== undefined);
 
   return allEventBusRules;
 };
+
+function isStandardRule(event: Rule) {
+  return !event.ManagedBy;
+}


### PR DESCRIPTION
# Exclude managed eventbridge rules

Some rules can be managed for example AWS creates a managed rule for eventbridge archives.

As these rules are managed by AWS, and can't be edited they should be excluded.