### PR TITLE
fix(Rule): noUnauthorizedRestApiGatewaysRoutes authorizer detection

### DIFF
--- a/packages/core/src/aws-sdk-helpers/apiGateway/fetchRestApiGatewayResources.ts
+++ b/packages/core/src/aws-sdk-helpers/apiGateway/fetchRestApiGatewayResources.ts
@@ -6,7 +6,7 @@ const fetchRestApiGatewayResourcesByArn = async (
   arn: RestApiGatewayApiARN,
 ): Promise<Resource[]> => {
   const { items } = await apiGatewayClient.send(
-    new GetResourcesCommand({ restApiId: arn.getApiId() }),
+    new GetResourcesCommand({ restApiId: arn.getApiId(), embed: ['methods'] }),
   );
 
   return items ?? [];

--- a/packages/core/src/rules/noUnauthorizedRestApiGatewaysRoutes/index.ts
+++ b/packages/core/src/rules/noUnauthorizedRestApiGatewaysRoutes/index.ts
@@ -4,13 +4,11 @@ import { fetchAllRestApiGatewayResources } from '../../aws-sdk-helpers';
 import { Rule } from '../../types';
 
 const isAuthenticated = (resource: Resource): boolean => {
-  const hasAuthorizer =
-    resource.resourceMethods !== undefined &&
-    Object.values(resource.resourceMethods).every(
-      method =>
-        method.authorizationType !== undefined &&
-        method.authorizationType !== 'NONE',
-    );
+  const hasAuthorizer = Object.values(resource.resourceMethods!).every(
+    method =>
+      method.authorizationType !== undefined &&
+      method.authorizationType !== 'NONE',
+  );
 
   return hasAuthorizer;
 };
@@ -21,11 +19,13 @@ const run: Rule['run'] = async resourceArns => {
   );
   const results = compact(
     restApiGatewaysResources.flatMap(({ arn, resources }) =>
-      resources.map(resource => ({
-        arn,
-        success: isAuthenticated(resource),
-        resource: resource.path,
-      })),
+      resources
+        .filter(resource => resource.resourceMethods)
+        .map(resource => ({
+          arn,
+          success: isAuthenticated(resource),
+          resource: resource.path,
+        })),
     ),
   );
 


### PR DESCRIPTION
# Fix noUnauthorizedRestApiGatewaysRoutes rule

The current rule did not pick up authorizers without specifying the embed property documented [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-api-gateway/Interface/GetResourcesCommandInput/), and didn't handle parent resources with no http methods.