### PR TITLE
fix(Cli): totals for non existent resources

### DIFF
--- a/packages/cli/src/results/getResultsByCategory.ts
+++ b/packages/cli/src/results/getResultsByCategory.ts
@@ -32,10 +32,13 @@ export const getResultsByCategory = (
     categories.forEach(category => (resultsByCategory[category] += ruleRatio));
   });
 
-  Object.entries(categoryTotals).forEach(
-    ([category, total]) =>
-      (resultsByCategory[category as Category] *= total > 0 ? 100 / total : 0),
-  );
+  Object.entries(categoryTotals).forEach(([category, total]) => {
+    if (total > 0) {
+      resultsByCategory[category as Category] *= total > 0 ? 100 / total : 0;
+    } else {
+      resultsByCategory[category as Category] = 100;
+    }
+  });
 
   return resultsByCategory;
 };


### PR DESCRIPTION
Currently for resources that are missing for entire categories the total % is calculated as 0 instead of 0.

Now we give a total of 100% for a category if no rules have run for it. Fixes #115

Replaces #211.