### PR TITLE
fix(Cli): list only s3 buckets in given region

### DIFF
--- a/packages/cli/src/init/listResources/s3/listS3Buckets.ts
+++ b/packages/cli/src/init/listResources/s3/listS3Buckets.ts
@@ -1,4 +1,7 @@
-import { ListBucketsCommand } from '@aws-sdk/client-s3';
+import {
+  GetBucketLocationCommand,
+  ListBucketsCommand,
+} from '@aws-sdk/client-s3';
 import { S3BucketARN, s3Client } from '@sls-mentor/core';
 
 export const listS3Buckets = async (): Promise<S3BucketARN[]> => {
@@ -8,5 +11,16 @@ export const listS3Buckets = async (): Promise<S3BucketARN[]> => {
     .map(({ Name }) => Name)
     .filter((name): name is string => name !== undefined);
 
-  return bucketNames.map(S3BucketARN.fromBucketName);
+  const bucketArns: S3BucketARN[] = [];
+
+  for (const bucketName of bucketNames) {
+    const { LocationConstraint } = await s3Client.send(
+      new GetBucketLocationCommand({ Bucket: bucketName }),
+    );
+    if (LocationConstraint === process.env.AWS_REGION) {
+      bucketArns.push(S3BucketARN.fromBucketName(bucketName));
+    }
+  }
+
+  return bucketArns;
 };


### PR DESCRIPTION
# list s3 buckets fix

We should only include the s3 buckets that match the given region, otherwise rules will fail for the buckets in other regions.

Fixes issues #113 #163.

Replaced pr #207.