### PR TITLE
fix(Rule): noUnauthorizedApiGatewaysV2Routes websocket routes

### DIFF
--- a/packages/core/src/aws-sdk-helpers/apiGatewayV2/fetchApiGatewayV2Routes.ts
+++ b/packages/core/src/aws-sdk-helpers/apiGatewayV2/fetchApiGatewayV2Routes.ts
@@ -1,4 +1,4 @@
-import { GetRoutesCommand, Route } from '@aws-sdk/client-apigatewayv2';
+import { GetRoutesCommand, GetApiCommand, Route, ProtocolType } from '@aws-sdk/client-apigatewayv2';
 import apiGatewayV2Client from '../../clients/apiGatewayV2Client';
 import { ApiGatewayV2ApiARN, CustomARN } from '../../types';
 
@@ -12,20 +12,33 @@ const fetchApiGatewayV2RoutesByArn = async (
   return Items ?? [];
 };
 
+const fetchApiGatewayProtocolTypeByArn = async (
+  arn: ApiGatewayV2ApiARN,
+): Promise<ProtocolType> => {
+  const { ProtocolType: protocolType } = await apiGatewayV2Client.send(
+    new GetApiCommand({ ApiId: arn.getApiId() }),
+  );
+  return protocolType! as ProtocolType;
+};
+
 export const fetchAllApiGatewayV2Routes = async (
   resourceArns: CustomARN[],
 ): Promise<
   {
     arn: ApiGatewayV2ApiARN;
     routes: Route[];
+    protocol: ProtocolType;
   }[]
 > => {
   const apiGatewaysV2 = CustomARN.filterArns(resourceArns, ApiGatewayV2ApiARN);
 
   return Promise.all(
-    apiGatewaysV2.map(async arn => ({
-      arn,
-      routes: await fetchApiGatewayV2RoutesByArn(arn),
-    })),
+    apiGatewaysV2.map(async arn => {
+      return {
+        arn,
+        routes: await fetchApiGatewayV2RoutesByArn(arn),
+        protocol: await fetchApiGatewayProtocolTypeByArn(arn),
+      }
+    }),
   );
 };

--- a/packages/core/src/rules/noUnauthorizedApiGatewaysV2Routes/index.ts
+++ b/packages/core/src/rules/noUnauthorizedApiGatewaysV2Routes/index.ts
@@ -1,22 +1,27 @@
-import { Route } from '@aws-sdk/client-apigatewayv2';
+import { Route, ProtocolType } from '@aws-sdk/client-apigatewayv2';
 import compact from 'lodash/compact';
 import { fetchAllApiGatewayV2Routes } from '../../aws-sdk-helpers';
 import { Rule } from '../../types';
 
-const isAuthenticated = (route: Route): boolean => {
-  const hasAuthorizer =
-    route.AuthorizationType !== undefined && route.AuthorizationType !== 'NONE';
+const isAuthenticated = (route: Route, protocol: ProtocolType): boolean => {
+  if (protocol === 'WEBSOCKET' && route.RouteKey !== '$connect') {
+    // only $connect can have an authorizer for websocket routes
+    return true
+  } else {
+    const hasAuthorizer =
+      route.AuthorizationType !== undefined && route.AuthorizationType !== 'NONE';
 
-  return hasAuthorizer;
+    return hasAuthorizer;
+  }
 };
 
 const run: Rule['run'] = async resourceArns => {
   const apiGatewaysV2Routes = await fetchAllApiGatewayV2Routes(resourceArns);
   const results = compact(
-    apiGatewaysV2Routes.flatMap(({ arn, routes }) =>
+    apiGatewaysV2Routes.flatMap(({ arn, routes, protocol }) =>
       routes.map(route => ({
         arn,
-        success: isAuthenticated(route),
+        success: isAuthenticated(route, protocol),
         route: route.RouteKey,
       })),
     ),


### PR DESCRIPTION
# websocket route fix

only the `$connect` route key can have an authorizer, let's ignore the other routes when the api gateway has protocol `WEBSOCKET`.

Replaced pr #206.