### PR TITLE
fix: remove duplicate from sidebar

### DIFF
--- a/packages/rules/src/types/service.ts
+++ b/packages/rules/src/types/service.ts
@@ -12,6 +12,5 @@ export const SERVICES = [
   'Backup',
   'ApiGateway',
   'SES',
-  'DynamoDB',
 ] as const;
-export type Service = typeof SERVICES[number];
+export type Service = (typeof SERVICES)[number];


### PR DESCRIPTION
DynamoDB appeader twice in the sidebar